### PR TITLE
Improve error message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3 (unreleased)
 ----------------
 
+- Improve error messages by including more detailed information.
+  [thet]
+
 - Do not wrap resource ``__repr__`` output in ``<>`` to render tracebacks
   properly in browser.
   [lenadax]
@@ -68,7 +71,7 @@ Changelog
   Modernize setup.[py|cfg].
   [jensens]
 
-- Added ``GracefulResourceRenderer``. 
+- Added ``GracefulResourceRenderer``.
   Fixes #1.
   [jensens]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.3 (unreleased)
 ----------------
 
+- Allow to pass an error_callback for the GracefulResourceRenderer.
+  This allows to run some code in an error case, e.g. to add a user-visible
+  status message.
+  [thet]
+
 - Also handle resource resolver errors gracefully in the GracefulResourceRenderer.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3 (unreleased)
 ----------------
 
+- Also handle resource resolver errors gracefully in the GracefulResourceRenderer.
+  [thet]
+
 - Improve error messages by including more detailed information.
   [thet]
 

--- a/webresource/_api.py
+++ b/webresource/_api.py
@@ -740,7 +740,19 @@ class GracefulResourceRenderer(ResourceRenderer):
 
     def render(self):
         lines = []
-        for resource in self.resolver.resolve():
+        resources = []
+
+        try:
+            resources = self.resolver.resolve()
+        except (
+            ResourceConflictError,
+            ResourceCircularDependencyError,
+            ResourceMissingDependencyError,
+        ) as e:
+            error_message = str(e)
+            logger.exception(error_message)
+
+        for resource in resources:
             error_message = None
             try:
                 lines.append(resource.render(self.base_url))

--- a/webresource/_api.py
+++ b/webresource/_api.py
@@ -738,7 +738,7 @@ class ResourceRenderer(object):
 class GracefulResourceRenderer(ResourceRenderer):
     """Resource renderer, which does not fail but logs an exception."""
 
-    def render(self):
+    def render(self, error_callback=None):
         lines = []
         resources = []
 
@@ -751,6 +751,8 @@ class GracefulResourceRenderer(ResourceRenderer):
         ) as e:
             error_message = str(e)
             logger.exception(error_message)
+            if error_callback:
+                error_callback(error_message)
 
         for resource in resources:
             error_message = None
@@ -768,4 +770,6 @@ class GracefulResourceRenderer(ResourceRenderer):
                         error_message
                     ))
                     logger.exception(error_message)
+                    if error_callback:
+                        error_callback(error_message)
         return u'\n'.join(lines)


### PR DESCRIPTION
## UPDATE @rnixx @lenadax 

I‌ changed the PR in CMFPlone to not belong anymore on this PR.
The callback isn't necessary anymore!

In this case, I'd even remove the callback commit.

However, at least the change which handles resolver errors gracefully is useful[

What do you think?



## Belongs together:

- https://github.com/conestack/webresource/pull/10
~~- https://github.com/plone/Products.CMFPlone/pull/4165~~ -> the CMFPlone PR doesn't depend anymore on this.

Dependency problem with resources without these fixes or by just using `webresource.GracefulResourceRenderer`:

![image](https://github.com/user-attachments/assets/5019cb5d-dffc-4e85-98c1-cf41d6b131f3)

Dependency problem with the two PRs in place:

![image](https://github.com/user-attachments/assets/ccc08015-d02a-4d90-9f49-947d560de4b5)


Note: The circular dependency problem seems to be incorrect.