### PR TITLE
Drop Python 3.7 support, add Python 3.13 support.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ jobs:
           - macos-latest
 
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3 (unreleased)
 ----------------
 
+- Drop Python 3.7 support, add Python 3.13 support.
+  [thet]
+
 - Do not wrap resource ``__repr__`` output in ``<>`` to render tracebacks
   properly in browser.
   [lenadax]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,12 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
 
 [options]


### PR DESCRIPTION
Python 3.7 is apparently not supported by GitHub Actions anymore. Also it's unsupported by Python itself.
But Python 3.13 is not stable.

See the test failures in:
https://github.com/conestack/webresource/pull/10

Update this in setup.cfg and GHA actions workflow.

I'd even remove support for Python 2.7 and update the code for f-strings and remove unicode literals, etc.
But that's another topic.

